### PR TITLE
[ESD-1097] Fix log preformat clang

### DIFF
--- a/include/internal/setting_def.h
+++ b/include/internal/setting_def.h
@@ -25,7 +25,7 @@ typedef struct setting_sbp_cb_s setting_sbp_cb_t;
  * as well as the list of types and settings necessary to perform
  * the registration, watching and callback functionality of the client.
  */
-typedef struct settings_s {
+struct settings_s {
   type_data_t *type_data_list;
   setting_data_t *setting_data_list;
   request_state_t request_state;
@@ -39,6 +39,6 @@ typedef struct settings_s {
   char resp_type[SETTINGS_BUFLEN];
   bool read_by_idx_done;
   settings_write_res_t status;
-} settings_t;
+};
 
 #endif /* LIBSETTINGS_SETTING_DEF_H */

--- a/include/internal/setting_sbp_cb.h
+++ b/include/internal/setting_sbp_cb.h
@@ -17,12 +17,12 @@
 
 #include <libsettings/settings.h>
 
-typedef struct setting_sbp_cb_s {
+struct setting_sbp_cb_s {
   uint16_t msg_id;
   sbp_msg_callback_t cb;
   sbp_msg_callbacks_node_t *cb_node;
   struct setting_sbp_cb_s *next;
-} setting_sbp_cb_t;
+};
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/settings.c
+++ b/src/settings.c
@@ -104,7 +104,8 @@ static const char *const bool_enum_names[] = {"False", "True", NULL};
 static settings_log_t client_log = NULL;
 
 /* Workaround for Cython not properly supporting variadic arguments */
-static void log_preformat(int level, const char *fmt, ...) {
+__attribute__((format(printf, 2, 3))) static void log_preformat(int level, const char *fmt, ...)
+{
   char buffer[256];
   va_list args;
   va_start(args, fmt);

--- a/tests/src/test_setting_data.cpp
+++ b/tests/src/test_setting_data.cpp
@@ -31,7 +31,7 @@ static setting_data_t *create_setting_data()
 
   EXPECT_EQ(0, res);
 
-  int var = 0;
+  static int var = 0;
 
   setting_data_t *setting_data = setting_data_create(type_data_list,
                                                      "section",


### PR DESCRIPTION
Fixed an error clang throws about calling `vsnprintf()` without a literal format string.

Also fixed a couple of warnings clang throws about duplicate struct typedefs. This is legal in C11, but the CMake files specifically use C99.

The `test_setting_data.format` unit test was also failing locally. The root cause was that the pointer to the variable was pointing to a local variable which was becoming invalid after the `create_setting_data()` function returned.