### PR TITLE
Travis: Use OSX native compiler [ESD-1097]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,11 @@ matrix:
      script:
        - git submodule update --init
        - mkdir build; cd build; cmake ../; make
+   - os: osx
+     osx_image: xcode10.1
+     script:
+       - git submodule update --init
+       - mkdir build; cd build; cmake ../; make
    - os: windows
      dist: 1803-containers
      python: "2.7"

--- a/src/settings.c
+++ b/src/settings.c
@@ -106,7 +106,7 @@ static settings_log_t client_log = NULL;
 /* Workaround for Cython not properly supporting variadic arguments */
 __attribute__((format(printf, 2, 3))) static void log_preformat(int level, const char *fmt, ...)
 {
-  char buffer[1024];
+  char buffer[SETTINGS_BUFLEN];
   va_list args;
   va_start(args, fmt);
   int ret = vsnprintf(buffer, sizeof(buffer), fmt, args);

--- a/src/settings.c
+++ b/src/settings.c
@@ -106,12 +106,20 @@ static settings_log_t client_log = NULL;
 /* Workaround for Cython not properly supporting variadic arguments */
 __attribute__((format(printf, 2, 3))) static void log_preformat(int level, const char *fmt, ...)
 {
-  char buffer[256];
+  char buffer[1024];
   va_list args;
   va_start(args, fmt);
-  vsnprintf(buffer, 256, fmt, args);
-  client_log(level, buffer);
+  int ret = vsnprintf(buffer, sizeof(buffer), fmt, args);
   va_end(args);
+
+  if (ret < 0) {
+    client_log(LOG_ERROR, "log_preformat encoding error");
+    return;
+  } else if ((size_t)ret >= sizeof(buffer)) {
+    client_log(LOG_WARN, "log_preformat too long message");
+  }
+
+  client_log(level, buffer);
 }
 
 /**


### PR DESCRIPTION
There were problems with AppleClang compiler. To avoid this in the future add a job with OSX native compiler in addition to allready existing GCC@6 job.