### PR TITLE
Build LSN as library [ESD-1116]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(libsettings)
 # Include Modules
 ################################################################################
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
-include(ClangTools)
+include(ClangToolsLibsettings)
 
 ################################################################################
 # Build Controls
@@ -115,7 +115,10 @@ else (LIBSBP_SEARCH_PATH)
   endif()
 endif(LIBSBP_SEARCH_PATH)
 
-include_directories("libswiftnav/include")
+if(EXISTS ${PROJECT_SOURCE_DIR}/libswiftnav)
+  include_directories("${PROJECT_SOURCE_DIR}/libswiftnav/include")
+  add_subdirectory("${PROJECT_SOURCE_DIR}/libswiftnav")
+endif()
 
 add_subdirectory(src)
 add_subdirectory(python)

--- a/cmake/ClangToolsLibsettings.cmake
+++ b/cmake/ClangToolsLibsettings.cmake
@@ -49,15 +49,15 @@ endif()
 
 if (EXISTS ${CLANG_FORMAT_PATH})
     # Format all files .c files (and their headers) in project
-    add_custom_target(clang-format-all
+    add_custom_target(clang-format-all-libsettings
         COMMAND git ls-files -- '../*.[ch]' '../*.cpp'
         | sed 's/^...//' | sed 's\#\^\#${CMAKE_SOURCE_DIR}/\#'
         | xargs clang-format -i)
 
     # Format all staged lines
-    add_custom_target(clang-format-head COMMAND git-clang-format)
+    add_custom_target(clang-format-head-libsettings COMMAND git-clang-format)
 
     # In-place format *.cc files that differ from master, and are not listed as
     # being DELETED.
-    add_custom_target(clang-format-diff COMMAND git-clang-format master)
+    add_custom_target(clang-format-diff-libsettings COMMAND git-clang-format master)
 endif()

--- a/include/internal/setting_declspec.h
+++ b/include/internal/setting_declspec.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef LIBSETTINGS_DECLSPEC_H
+#define LIBSETTINGS_DECLSPEC_H
+
+#if defined(_MSC_VER)
+#if defined(settings_EXTENSION)
+/* If building Python C extension -> leave empty */
+#define LIBSETTINGS_DECLSPEC
+#elif defined(settings_EXPORTS) /* settings_EXTENSION */
+#define LIBSETTINGS_DECLSPEC __declspec(dllexport)
+#else /* settings_EXPORTS */
+#define LIBSETTINGS_DECLSPEC __declspec(dllimport)
+#endif                  /* settings_EXPORTS */
+#elif defined(__GNUC__) /* _MSC_VER */
+#define LIBSETTINGS_DECLSPEC __attribute__((visibility("default")))
+#else /* __GNUC__ */
+#pragma error Unknown dynamic link import / export semantics.
+#endif /* __GNUC__ */
+
+#endif /* LIBSETTINGS_DECLSPEC_H */

--- a/include/libsettings/settings.h
+++ b/include/libsettings/settings.h
@@ -27,15 +27,7 @@
 
 #include <libsbp/sbp.h>
 
-#if defined(_MSC_VER)
-#define LIBSETTINGS_EXPORT __declspec(dllexport)
-#define LIBSETTINGS_IMPORT __declspec(dllimport)
-#elif defined(__GNUC__)
-#define LIBSETTINGS_EXPORT __attribute__((visibility("default")))
-#define LIBSETTINGS_IMPORT
-#else
-#pragma error Unknown dynamic link import / export semantics.
-#endif
+#include <internal/setting_declspec.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -149,7 +141,7 @@ typedef int (*settings_notify_fn)(void *context);
  * @return                  Pointer to the created context, or NULL if the
  *                          operation failed.
  */
-LIBSETTINGS_EXPORT settings_t *settings_create(uint16_t sender_id, settings_api_t *api_impl);
+LIBSETTINGS_DECLSPEC settings_t *settings_create(uint16_t sender_id, settings_api_t *api_impl);
 
 /**
  * @brief   Destroy a settings context.
@@ -159,7 +151,7 @@ LIBSETTINGS_EXPORT settings_t *settings_create(uint16_t sender_id, settings_api_
  *
  * @param[inout] ctx        Double pointer to the context to destroy.
  */
-LIBSETTINGS_EXPORT void settings_destroy(settings_t **ctx);
+LIBSETTINGS_DECLSPEC void settings_destroy(settings_t **ctx);
 
 /**
  * @brief   Register an enum type.
@@ -174,9 +166,9 @@ LIBSETTINGS_EXPORT void settings_destroy(settings_t **ctx);
  * @retval 0                The enum type was registered successfully.
  * @retval -1               An error occurred.
  */
-LIBSETTINGS_EXPORT int settings_register_enum(settings_t *ctx,
-                                              const char *const enum_names[],
-                                              settings_type_t *type);
+LIBSETTINGS_DECLSPEC int settings_register_enum(settings_t *ctx,
+                                                const char *const enum_names[],
+                                                settings_type_t *type);
 
 /**
  * @brief   Register a setting.
@@ -200,14 +192,14 @@ LIBSETTINGS_EXPORT int settings_register_enum(settings_t *ctx,
  * @retval 0                The setting was registered successfully.
  * @retval -1               An error occurred.
  */
-LIBSETTINGS_EXPORT int settings_register_setting(settings_t *ctx,
-                                                 const char *section,
-                                                 const char *name,
-                                                 void *var,
-                                                 size_t var_len,
-                                                 settings_type_t type,
-                                                 settings_notify_fn notify,
-                                                 void *notify_context);
+LIBSETTINGS_DECLSPEC int settings_register_setting(settings_t *ctx,
+                                                   const char *section,
+                                                   const char *name,
+                                                   void *var,
+                                                   size_t var_len,
+                                                   settings_type_t type,
+                                                   settings_notify_fn notify,
+                                                   void *notify_context);
 
 /**
  * @brief   Register a read-only setting.
@@ -225,12 +217,12 @@ LIBSETTINGS_EXPORT int settings_register_setting(settings_t *ctx,
  * @retval 0                The setting was registered successfully.
  * @retval -1               An error occurred.
  */
-LIBSETTINGS_EXPORT int settings_register_readonly(settings_t *ctx,
-                                                  const char *section,
-                                                  const char *name,
-                                                  const void *var,
-                                                  size_t var_len,
-                                                  settings_type_t type);
+LIBSETTINGS_DECLSPEC int settings_register_readonly(settings_t *ctx,
+                                                    const char *section,
+                                                    const char *name,
+                                                    const void *var,
+                                                    size_t var_len,
+                                                    settings_type_t type);
 
 /**
  * @brief   Create and add a watch only setting.
@@ -251,14 +243,14 @@ LIBSETTINGS_EXPORT int settings_register_readonly(settings_t *ctx,
  * @retval 0                The setting was registered successfully.
  * @retval -1               An error occurred.
  */
-LIBSETTINGS_EXPORT int settings_register_watch(settings_t *ctx,
-                                               const char *section,
-                                               const char *name,
-                                               void *var,
-                                               size_t var_len,
-                                               settings_type_t type,
-                                               settings_notify_fn notify,
-                                               void *notify_context);
+LIBSETTINGS_DECLSPEC int settings_register_watch(settings_t *ctx,
+                                                 const char *section,
+                                                 const char *name,
+                                                 void *var,
+                                                 size_t var_len,
+                                                 settings_type_t type,
+                                                 settings_notify_fn notify,
+                                                 void *notify_context);
 
 /**
  * @brief   Write a new value for registered setting.
@@ -276,12 +268,12 @@ LIBSETTINGS_EXPORT int settings_register_watch(settings_t *ctx,
  * @retval 0                The setting was written successfully.
  * @retval >0               Response returned an error @see settings_write_res_t
  */
-LIBSETTINGS_EXPORT settings_write_res_t settings_write(settings_t *ctx,
-                                                       const char *section,
-                                                       const char *name,
-                                                       const void *value,
-                                                       size_t value_len,
-                                                       settings_type_t type);
+LIBSETTINGS_DECLSPEC settings_write_res_t settings_write(settings_t *ctx,
+                                                         const char *section,
+                                                         const char *name,
+                                                         const void *value,
+                                                         size_t value_len,
+                                                         settings_type_t type);
 
 /**
  * @brief   Write a new value for registered setting of type int.
@@ -297,10 +289,10 @@ LIBSETTINGS_EXPORT settings_write_res_t settings_write(settings_t *ctx,
  * @retval 0                The setting was written successfully.
  * @retval >0               Response returned an error @see settings_write_res_t
  */
-LIBSETTINGS_EXPORT settings_write_res_t settings_write_int(settings_t *ctx,
-                                                           const char *section,
-                                                           const char *name,
-                                                           int value);
+LIBSETTINGS_DECLSPEC settings_write_res_t settings_write_int(settings_t *ctx,
+                                                             const char *section,
+                                                             const char *name,
+                                                             int value);
 
 /**
  * @brief   Write a new value for registered setting of type float.
@@ -316,10 +308,10 @@ LIBSETTINGS_EXPORT settings_write_res_t settings_write_int(settings_t *ctx,
  * @retval 0                The setting was written successfully.
  * @retval >0               Response returned an error @see settings_write_res_t
  */
-LIBSETTINGS_EXPORT settings_write_res_t settings_write_float(settings_t *ctx,
-                                                             const char *section,
-                                                             const char *name,
-                                                             float value);
+LIBSETTINGS_DECLSPEC settings_write_res_t settings_write_float(settings_t *ctx,
+                                                               const char *section,
+                                                               const char *name,
+                                                               float value);
 
 /**
  * @brief   Write a new value for registered setting of type str.
@@ -335,10 +327,10 @@ LIBSETTINGS_EXPORT settings_write_res_t settings_write_float(settings_t *ctx,
  * @retval 0                The setting was written successfully.
  * @retval >0               Response returned an error @see settings_write_res_t
  */
-LIBSETTINGS_EXPORT settings_write_res_t settings_write_str(settings_t *ctx,
-                                                           const char *section,
-                                                           const char *name,
-                                                           const char *str);
+LIBSETTINGS_DECLSPEC settings_write_res_t settings_write_str(settings_t *ctx,
+                                                             const char *section,
+                                                             const char *name,
+                                                             const char *str);
 
 /**
  * @brief   Write a new value for registered setting of type bool.
@@ -354,10 +346,10 @@ LIBSETTINGS_EXPORT settings_write_res_t settings_write_str(settings_t *ctx,
  * @retval 0                The setting was written successfully.
  * @retval >0               Response returned an error @see settings_write_res_t
  */
-LIBSETTINGS_EXPORT settings_write_res_t settings_write_bool(settings_t *ctx,
-                                                            const char *section,
-                                                            const char *name,
-                                                            bool value);
+LIBSETTINGS_DECLSPEC settings_write_res_t settings_write_bool(settings_t *ctx,
+                                                              const char *section,
+                                                              const char *name,
+                                                              bool value);
 
 /**
  * @brief   Read value of registered setting.
@@ -373,12 +365,12 @@ LIBSETTINGS_EXPORT settings_write_res_t settings_write_bool(settings_t *ctx,
  * @return                  The operation result.
  * @retval 0                The setting was read successfully. Error otherwise.
  */
-LIBSETTINGS_EXPORT int settings_read(settings_t *ctx,
-                                     const char *section,
-                                     const char *name,
-                                     void *value,
-                                     size_t value_len,
-                                     settings_type_t type);
+LIBSETTINGS_DECLSPEC int settings_read(settings_t *ctx,
+                                       const char *section,
+                                       const char *name,
+                                       void *value,
+                                       size_t value_len,
+                                       settings_type_t type);
 
 /**
  * @brief   Read value of registered setting of type int.
@@ -392,10 +384,10 @@ LIBSETTINGS_EXPORT int settings_read(settings_t *ctx,
  * @return                  The operation result.
  * @retval 0                The setting was read successfully. Error otherwise.
  */
-LIBSETTINGS_EXPORT int settings_read_int(settings_t *ctx,
-                                         const char *section,
-                                         const char *name,
-                                         int *value);
+LIBSETTINGS_DECLSPEC int settings_read_int(settings_t *ctx,
+                                           const char *section,
+                                           const char *name,
+                                           int *value);
 
 /**
  * @brief   Read value of registered setting of type float.
@@ -409,10 +401,10 @@ LIBSETTINGS_EXPORT int settings_read_int(settings_t *ctx,
  * @return                  The operation result.
  * @retval 0                The setting was read successfully. Error otherwise.
  */
-LIBSETTINGS_EXPORT int settings_read_float(settings_t *ctx,
-                                           const char *section,
-                                           const char *name,
-                                           float *value);
+LIBSETTINGS_DECLSPEC int settings_read_float(settings_t *ctx,
+                                             const char *section,
+                                             const char *name,
+                                             float *value);
 
 /**
  * @brief   Read value of registered setting of type str.
@@ -427,11 +419,11 @@ LIBSETTINGS_EXPORT int settings_read_float(settings_t *ctx,
  * @return                  The operation result.
  * @retval 0                The setting was read successfully. Error otherwise.
  */
-LIBSETTINGS_EXPORT int settings_read_str(settings_t *ctx,
-                                         const char *section,
-                                         const char *name,
-                                         char *str,
-                                         size_t str_len);
+LIBSETTINGS_DECLSPEC int settings_read_str(settings_t *ctx,
+                                           const char *section,
+                                           const char *name,
+                                           char *str,
+                                           size_t str_len);
 
 /**
  * @brief   Read value of registered setting of type bool.
@@ -445,10 +437,10 @@ LIBSETTINGS_EXPORT int settings_read_str(settings_t *ctx,
  * @return                  The operation result.
  * @retval 0                The setting was read successfully. Error otherwise.
  */
-LIBSETTINGS_EXPORT int settings_read_bool(settings_t *ctx,
-                                          const char *section,
-                                          const char *name,
-                                          bool *value);
+LIBSETTINGS_DECLSPEC int settings_read_bool(settings_t *ctx,
+                                            const char *section,
+                                            const char *name,
+                                            bool *value);
 
 /**
  * @brief   Read value of registered setting based on index.
@@ -470,16 +462,16 @@ LIBSETTINGS_EXPORT int settings_read_bool(settings_t *ctx,
  * @retval <0               Error.
  * @retval >0               Last index was read successfully. There are no more indexes to read.
  */
-LIBSETTINGS_EXPORT int settings_read_by_idx(settings_t *ctx,
-                                            uint16_t idx,
-                                            char *section,
-                                            size_t section_len,
-                                            char *name,
-                                            size_t name_len,
-                                            char *value,
-                                            size_t value_len,
-                                            char *type,
-                                            size_t type_len);
+LIBSETTINGS_DECLSPEC int settings_read_by_idx(settings_t *ctx,
+                                              uint16_t idx,
+                                              char *section,
+                                              size_t section_len,
+                                              char *name,
+                                              size_t name_len,
+                                              char *value,
+                                              size_t value_len,
+                                              char *type,
+                                              size_t type_len);
 
 #ifdef __cplusplus
 }

--- a/include/libsettings/settings.h
+++ b/include/libsettings/settings.h
@@ -27,7 +27,7 @@
 
 #include <libsbp/sbp.h>
 
-#include <internal/setting_declspec.h>
+#include <libsettings/settings_declspec.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/libsettings/settings_declspec.h
+++ b/include/libsettings/settings_declspec.h
@@ -10,8 +10,8 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifndef LIBSETTINGS_DECLSPEC_H
-#define LIBSETTINGS_DECLSPEC_H
+#ifndef LIBSETTINGS_SETTINGS_DECLSPEC_H
+#define LIBSETTINGS_SETTINGS_DECLSPEC_H
 
 #if defined(_MSC_VER)
 #if defined(settings_EXTENSION)
@@ -28,4 +28,4 @@
 #pragma error Unknown dynamic link import / export semantics.
 #endif /* __GNUC__ */
 
-#endif /* LIBSETTINGS_DECLSPEC_H */
+#endif /* LIBSETTINGS_SETTINGS_DECLSPEC_H */

--- a/include/libsettings/settings_util.h
+++ b/include/libsettings/settings_util.h
@@ -15,6 +15,8 @@
 
 #include <inttypes.h>
 
+#include <internal/setting_declspec.h>
+
 typedef enum settings_tokens_e {
   SETTINGS_TOKENS_INVALID = -1,   /** An error occurred */
   SETTINGS_TOKENS_EMPTY = 0,      /** No tokens found */
@@ -31,12 +33,12 @@ typedef enum settings_tokens_e {
 extern "C" {
 #endif
 
-int settings_format(const char *section,
-                    const char *name,
-                    const char *value,
-                    const char *type,
-                    char *buf,
-                    size_t blen);
+LIBSETTINGS_DECLSPEC int settings_format(const char *section,
+                                         const char *name,
+                                         const char *value,
+                                         const char *type,
+                                         char *buf,
+                                         size_t blen);
 
 /**
  * @brief   Parse setting strings from SBP message buffer
@@ -56,12 +58,12 @@ int settings_format(const char *section,
  *                          5 is found, -1 is returned. See @ settings_tokens_t.
  * @retval -1               An error occurred.
  */
-settings_tokens_t settings_parse(const char *buf,
-                                 size_t blen,
-                                 const char **section,
-                                 const char **name,
-                                 const char **value,
-                                 const char **type);
+LIBSETTINGS_DECLSPEC settings_tokens_t settings_parse(const char *buf,
+                                                      size_t blen,
+                                                      const char **section,
+                                                      const char **name,
+                                                      const char **value,
+                                                      const char **type);
 
 #ifdef __cplusplus
 }

--- a/include/libsettings/settings_util.h
+++ b/include/libsettings/settings_util.h
@@ -15,7 +15,7 @@
 
 #include <inttypes.h>
 
-#include <internal/setting_declspec.h>
+#include <libsettings/settings_declspec.h>
 
 typedef enum settings_tokens_e {
   SETTINGS_TOKENS_INVALID = -1,   /** An error occurred */

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -46,10 +46,10 @@ libraries = []
 
 if os.name == 'nt':
     if py_version == '27' or py_version == '34':
-      ldflags.append("-static-libgcc")
-      libraries.append("python{}-gen".format(py_version))
+        ldflags.append("-static-libgcc")
+        libraries.append("python{}-gen".format(py_version))
     else:
-       cflags = []
+        cflags = ['/Dsettings_EXTENSION', '/Dswiftnav_EXTENSION']
 
 setup(
     name='libsettings',

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,6 @@ set(libsettings_HEADERS
   )
 
 add_library(settings
-            ${PROJECT_SOURCE_DIR}/libswiftnav/src/logging.c
-            ${PROJECT_SOURCE_DIR}/libswiftnav/src/logging_common.c
             settings.c
             settings_util.c
             request_state.c
@@ -17,7 +15,7 @@ add_library(settings
             setting_type_int.c
             setting_type_str.c)
 
-target_link_libraries(settings)
+target_link_libraries(settings swiftnav)
 
 target_include_directories(settings PUBLIC ${PROJECT_SOURCE_DIR}/include)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(libsettings_HEADERS
   ${PROJECT_SOURCE_DIR}/include/libsettings/settings.h
+  ${PROJECT_SOURCE_DIR}/include/libsettings/settings_declspec.h
   ${PROJECT_SOURCE_DIR}/include/libsettings/settings_util.h
   )
 

--- a/src/setting_sbp_cb.c
+++ b/src/setting_sbp_cb.c
@@ -168,10 +168,7 @@ static int setting_update_watch_only(settings_t *ctx, const char *msg, uint8_t l
   return 0;
 }
 
-static void setting_read_resp_callback(uint16_t sender_id,
-                                       uint8_t len,
-                                       uint8_t msg[],
-                                       void *context)
+static void setting_read_resp_callback(uint16_t sender_id, uint8_t len, uint8_t *msg, void *context)
 {
   (void)sender_id;
   assert(msg);


### PR DESCRIPTION
Currently LSN logging module files are included in the libsettings build itself. This approach doesn't work with the PBR packaging scheme.

Move to actual library approach.

## Testing
PBR:
https://github.com/swift-nav/piksi_buildroot/pull/1173