### PR TITLE
Use system defined install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(libsettings)
 ################################################################################
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 include(ClangToolsLibsettings)
+include(GNUInstallDirs)
 
 ################################################################################
 # Build Controls

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,5 +20,5 @@ target_link_libraries(settings swiftnav)
 
 target_include_directories(settings PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
-install(TARGETS settings DESTINATION lib)
-install(FILES ${libsettings_HEADERS} DESTINATION include/libsettings)
+install(TARGETS settings DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
+install(FILES ${libsettings_HEADERS} DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/libsettings)


### PR DESCRIPTION
Use the cmake module GNUInstallDirs to define standard system install paths. This module works well when providing an installation prefix or destdir to cmake/make. This will replace all hard coded installation paths