### PR TITLE
Tidy up some cmake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,9 @@ option(libswiftnav_ENABLE_TESTS "" OFF)
 find_package(Swiftnav REQUIRED)
 
 add_subdirectory(src)
-add_subdirectory(python)
+if(libsettings_ENABLE_PYTHON)
+  add_subdirectory(python)
+endif()
 
 if(libsettings_BUILD_TESTS)
   add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,19 +34,25 @@ swift_setup_clang_tidy(PATTERNS "src/*.c")
 ################################################################################
 # Build Controls
 ################################################################################
-# When not explicitly provided, default to building shared libraries where possible.
-set(BUILD_SHARED_LIBS ON CACHE BOOL "If set, build shared libraries where possible.")
-# When not explicitly provided, default to debug release build.
-#
-# NOTE: CMake project generation sets the cache variable to the empty string on
-#       initialization. In order to account for this, it is  necessary to use the
-#       explicit 'if' statement in conjunction with the 'FORCE' directive.
-if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
-        "Choose one: None Debug Release RelWithDebInfo MinSizeRel Coverage." FORCE)
-endif(NOT CMAKE_BUILD_TYPE)
-# Enable static stack analyzer, defaults to off.
-option(ENABLE_STACK_ANALYSIS "Enable stack analysis. Requires gcc." OFF)
+# Only apply defaults when this is the top level project
+################################################################################
+if(${PROJECT_NAME} STREQUAL ${CMAKE_PROJECT_NAME})
+  # When not explicitly provided, default to building shared libraries where possible.
+  set(BUILD_SHARED_LIBS ON CACHE BOOL "If set, build shared libraries where possible.")
+  # When not explicitly provided, default to debug release build.
+  #
+  # NOTE: CMake project generation sets the cache variable to the empty string on
+  #       initialization. In order to account for this, it is  necessary to use the
+  #       explicit 'if' statement in conjunction with the 'FORCE' directive.
+  if(NOT CMAKE_BUILD_TYPE)
+      set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
+          "Choose one: None Debug Release RelWithDebInfo MinSizeRel Coverage." FORCE)
+  endif(NOT CMAKE_BUILD_TYPE)
+  # Enable static stack analyzer, defaults to off.
+  option(ENABLE_STACK_ANALYSIS "Enable stack analysis. Requires gcc." OFF)
+  # Selectively enable python support, defaults to on.
+  option(libsettings_ENABLE_PYTHON "Enable building of python module" ON)
+endif()
 
 ################################################################################
 # Source Code Configuration


### PR DESCRIPTION
1 - Don't force BUILD_SHARED_LIBS option when libsettings is included as a subproject of something else

2 - Provide option to disable python support (required in piksi_apps)