### PR TITLE
Avoid assert in request_state_init when using local state

### DIFF
--- a/src/request_state.c
+++ b/src/request_state.c
@@ -46,8 +46,6 @@ void request_state_init(request_state_t *state,
                         const char *data,
                         size_t data_len)
 {
-  assert(!state->pending);
-
   memset(state, 0, sizeof(request_state_t));
 
   assert(data_len <= sizeof(state->compare_data));


### PR DESCRIPTION
on pbrp, we were getting the following assert when registering the enum setting "uart0:mode": 

/home/jenkins/workspace/v_piksi_buildroot_private_master/buildroot/output/internal/build/piksi_apps-34ac376bc5d9d83c8ee373db395ee9625441bdc5/third_party/libsettings/src/request_state.c:49: request_state_init: Assertion `!state->pending' failed.
Aborted (core dumped)

I think this is because the code used to rely on a stack variable like request_state having been initialized to zero.  In all cases I see in libsettings, a request state is created on the stack an it relies on setting_perform_request_reply_from() to initialize the item with the request_state_init() function.  As such, I do not think it is appropriate for request_state_init() to assert on pending being false and propose we remove it.