### PR TITLE
Fix -Werror=stringop-overflow= errors with gcc 8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
 Open source SwiftNav settings API library.
 
-`libsettings` aims to provide standardized settings framework for projects accessing Piksi settings.
+`libsettings` aims to provide a standardized settings framework for projects accessing Piksi settings.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ is used.
 ``` sh
 mkdir build
 cd build
-cmake .. # If you want to speficy python version: 'cmake -D PYTHON=python3 ..'
+cmake .. # If you want to specify python version: 'cmake -D PYTHON=python3 ..'
 make
 cd ..
 ```

--- a/src/setting_data.c
+++ b/src/setting_data.c
@@ -66,7 +66,7 @@ setting_data_t *setting_data_create(type_data_t *type_list,
   } else {
     strncpy(setting_data->section, section, section_len - 1);
     setting_data->section[section_len - 1] = '\0';
-    strcpy(setting_data->name, name, name_len - 1);
+    strncpy(setting_data->name, name, name_len - 1);
     setting_data->name[name_len - 1] = '\0';
   }
 

--- a/src/setting_data.c
+++ b/src/setting_data.c
@@ -64,8 +64,10 @@ setting_data_t *setting_data_create(type_data_t *type_list,
     free(setting_data);
     setting_data = NULL;
   } else {
-    strcpy(setting_data->section, section);
-    strcpy(setting_data->name, name);
+    strncpy(setting_data->section, section, section_len - 1);
+    setting_data->section[section_len - 1] = '\0';
+    strcpy(setting_data->name, name, name_len - 1);
+    setting_data->name[name_len - 1] = '\0';
   }
 
   return setting_data;

--- a/src/setting_data.c
+++ b/src/setting_data.c
@@ -64,8 +64,8 @@ setting_data_t *setting_data_create(type_data_t *type_list,
     free(setting_data);
     setting_data = NULL;
   } else {
-    strncpy(setting_data->section, section, section_len);
-    strncpy(setting_data->name, name, name_len);
+    strcpy(setting_data->section, section);
+    strcpy(setting_data->name, name);
   }
 
   return setting_data;

--- a/src/setting_sbp_cb.c
+++ b/src/setting_sbp_cb.c
@@ -268,7 +268,6 @@ static void setting_read_by_index_resp_callback(uint16_t sender_id,
     if (section) {
       strncpy(state->resp_section, section, sizeof(state->resp_section) - 1);
       state->resp_section[sizeof(state->resp_section) - 1] = '\0';
-
     }
     if (name) {
       strncpy(state->resp_name, name, sizeof(state->resp_name) - 1);

--- a/src/setting_sbp_cb.c
+++ b/src/setting_sbp_cb.c
@@ -192,11 +192,13 @@ static void setting_read_resp_callback(uint16_t sender_id, uint8_t len, uint8_t 
     settings_parse(read_response->setting, len, &section, &name, &value, &type);
   if (tokens >= SETTINGS_TOKENS_VALUE) {
     if (value) {
-      strncpy(state->resp_value, value, sizeof(state->resp_value));
+      strncpy(state->resp_value, value, sizeof(state->resp_value) - 1);
+      state->resp_value[sizeof(state->resp_value) - 1] = '\0';
       state->resp_value_valid = true;
     }
     if (type) {
-      strncpy(state->resp_type, type, sizeof(state->resp_type));
+      strncpy(state->resp_type, type, sizeof(state->resp_type) - 1);
+      state->resp_type[sizeof(state->resp_type) - 1] = '\0';
     }
   } else if (tokens == SETTINGS_TOKENS_NAME) {
     log_debug("setting %s.%s not found", section, name);
@@ -264,17 +266,22 @@ static void setting_read_by_index_resp_callback(uint16_t sender_id,
   if (settings_parse(resp->setting, len - sizeof(resp->index), &section, &name, &value, &type)
       > 0) {
     if (section) {
-      strncpy(state->resp_section, section, sizeof(state->resp_section));
+      strncpy(state->resp_section, section, sizeof(state->resp_section) - 1);
+      state->resp_section[sizeof(state->resp_section) - 1] = '\0';
+
     }
     if (name) {
-      strncpy(state->resp_name, name, sizeof(state->resp_name));
+      strncpy(state->resp_name, name, sizeof(state->resp_name) - 1);
+      state->resp_name[sizeof(state->resp_name) - 1] = '\0';
     }
     if (value) {
-      strncpy(state->resp_value, value, sizeof(state->resp_value));
+      strncpy(state->resp_value, value, sizeof(state->resp_value) - 1);
+      state->resp_value[sizeof(state->resp_value) - 1] = '\0';
       state->resp_value_valid = true;
     }
     if (type) {
-      strncpy(state->resp_type, type, sizeof(state->resp_type));
+      strncpy(state->resp_type, type, sizeof(state->resp_type) - 1);
+      state->resp_type[sizeof(state->resp_type) - 1] = '\0';
     }
   }
 


### PR DESCRIPTION
gcc 8.3 produces errors about potential string overflows when compiled with -Wall which become errors when -Werror is also specified