### PR TITLE
Fix -Werror=stringop-overflow= errors with gcc 8.3 (again)

### DIFF
--- a/src/setting_data.c
+++ b/src/setting_data.c
@@ -41,12 +41,12 @@ setting_data_t *setting_data_create(type_data_t *type_list,
     return NULL;
   }
 
-  size_t section_len = strlen(section) + 1;
-  size_t name_len = strlen(name) + 1;
+  size_t section_len = strlen(section);
+  size_t name_len = strlen(name);
 
   *setting_data = (setting_data_t){
-    .section = malloc(section_len),
-    .name = malloc(name_len),
+    .section = malloc(section_len + 1),
+    .name = malloc(name_len + 1),
     .var = var,
     .var_len = var_len,
     .var_copy = malloc(var_len),
@@ -64,10 +64,8 @@ setting_data_t *setting_data_create(type_data_t *type_list,
     free(setting_data);
     setting_data = NULL;
   } else {
-    strncpy(setting_data->section, section, section_len - 1);
-    setting_data->section[section_len - 1] = '\0';
-    strncpy(setting_data->name, name, name_len - 1);
-    setting_data->name[name_len - 1] = '\0';
+    memcpy(setting_data->section, section, section_len + 1);
+    memcpy(setting_data->name, name, name_len + 1);
   }
 
   return setting_data;


### PR DESCRIPTION
The original fix which I proposed in https://github.com/swift-nav/libsettings/pull/251 fixed compilation with gcc 8.3 but the changes requested by @silverjam broke it again (because gcc complains about using `strncpy()` with a length argument derived from a parameter).  This fix avoids the use of both `strcpy()` and `strncpy()`