### PR TITLE
Auto-merge dependabot PRs [DEVINFRA-285]

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,18 @@
+name: Add comment to successful Dependabot PRs
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  add-dependabot-comment:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' && github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Add merge comment for dependabot PRs
+        uses: jo-sm/automerge-dependabot@v1
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          token: ${{ secrets.REPO_COMMENT_TOKEN }}


### PR DESCRIPTION
Requires a tokem with comment access to add the comment to Dependabot PRs, to be put into secret named `REPO_COMMENT_TOKEN`.

I've added an issue in the GitHub action about my slightly different way of invoking the action. https://github.com/jo-sm/at-dependabot-merge/issues/1

Currently it fires whenever the "CI" workflow is successful, ignoring the Lint and Python workflows.
If this general approach is acceptable, the three workflows can be tied together either sequentially or concurrently with a new workflow that waits on them all.

Tested at https://github.com/jayvdb/jekyll-netlify/pull/8