### PR TITLE
Make Compatible with Updated CMake Library [BUILD-9]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ swift_create_project_options(
 include(ClangFormat)
 swift_setup_clang_format()
 
-include(ClangTidy)
+include(OldClangTidy)
 swift_setup_clang_tidy(PATTERNS "src/*.c")
 
 ################################################################################


### PR DESCRIPTION
Fixes libsettings to build against new changes in our cmake
library.

Specifically the cmake function swift_setup_clang_tidy has been
moved to OldClangTidy.cmake

This function has been deprecated in favor of
swift_create_clang_tidy_targets, but this codebase will continue to
use the legacy method. For more explanation see the original [jira](https://swift-nav.atlassian.net/browse/BUILD-9)