### PR TITLE
Added new DR message dr_timeout_pos_stddev

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -547,7 +547,7 @@
   default value: '600'
   readonly: false
   Description: Indicates the maximum duration in seconds for which the inertial system will dead reckon.
-  Notes:       The default value of 600 seconds was chosen as the expected duration for which the Duro Inertial solution can maintain sub-meter accuracy.
+  Notes: The default value of 600 seconds was chosen as the expected duration for which the Duro Inertial solution can maintain sub-meter accuracy.
 
   group: ins
   name: dr_timeout_pos_stddev
@@ -557,7 +557,7 @@
   default value: '20'
   readonly: false
   Description: Indicates the maximum standard deviation of position for which the inertial system will dead reckon.
-  Notes:       The default value of 20 meters was chosen as the logical minimum standard of the position accuracy during dead reckon mode. 
+  Notes: The default value of 20 meters was chosen as the logical minimum standard of the position accuracy during dead reckon mode. 
 -
   group: ins
   name: build_name

--- a/settings.yaml
+++ b/settings.yaml
@@ -549,7 +549,17 @@
   Description: Indicates the maximum duration in seconds for which the inertial system will dead reckon.
   Notes:       The default value of 600 seconds was chosen as the expected duration for which the Duro Inertial solution can maintain sub-meter accuracy.
 
-- group: ins
+  group: ins
+  name: dr_timeout_pos_stddev
+  expert: false
+  type: double
+  units: meters
+  default value: '20'
+  readonly: false
+  Description: Indicates the maximum standard deviation of position for which the inertial system will dead reckon.
+  Notes:       The default value of 20 meters was chosen as the logical minimum standard of the position accuracy during dead reckon mode. 
+-
+  group: ins
   name: build_name
   expert: true
   type: string


### PR DESCRIPTION
This commit is a follow up from https://github.com/swift-nav/piksi_apps/pull/1749

A new setting "dr_timeout_pos_stddev" was opened up in Piksi v3.0.7. The corresponding settings are added to the yaml in this PR. 

