### PR TITLE
Fix MSVC Build [DEVINFRA-654]

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -93,6 +93,11 @@
 #include <internal/setting_type_int.h>
 #include <internal/setting_type_str.h>
 
+/* This is GCC specific so void for others */
+#ifndef __GNUC__
+#define __attribute__(x)
+#endif
+
 #define REGISTER_TIMEOUT_MS 500
 #define REGISTER_TRIES 5
 


### PR DESCRIPTION
Fixes the build issue after updating the libswiftnav dependency.

`settings.c` uses the gcc only symbol `__attribute__`, apparently to get around some cython issues.

This worked because it includes the `libswiftnav` header `logging.h`, which previously used to #define this symbol to void when not using gcc: [link](https://github.com/swift-nav/libswiftnav/blob/c580b9d041a7b6727ea7efdfa3fc9e6443e902f0/include/swiftnav/logging.h#L25)

That macro has been removed from `logging.h` and so the symbol is now undefined from the perspective of the compiler.

This adds the missing definition to `settings.c` to fix the build.