### PR TITLE
Fix sonarcloud analysis warning, restrict python version to avoid distutils issues

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,11 +1,11 @@
 ---
 name: CMake
-'on':
+"on":
   push:
     branches:
-      - 'master'
+      - "master"
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      - "v[0-9]+.[0-9]+.[0-9]+*"
   pull_request: ~
 jobs:
   # Regular C build with two compilers, using the environment:
@@ -35,7 +35,7 @@ jobs:
   linters:
     strategy:
       matrix:
-        preset: [ cppcheck, clang-tidy ]
+        preset: [cppcheck, clang-tidy]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -53,7 +53,7 @@ jobs:
       matrix:
         preset:
           - clang-sanitize-address
-#          - clang-sanitize-memory
+          #          - clang-sanitize-memory
           - clang-sanitize-undefined
     runs-on: ubuntu-latest
     steps:
@@ -83,7 +83,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     env:
-      SONAR_SCANNER_VERSION: 4.7.0.2747
+      SONAR_SCANNER_VERSION: 5.0.1.3006
       SONAR_SERVER_URL: "https://sonarcloud.io"
       SONAR_ORG: swift-nav
       SONAR_PROJECT_KEY: swift-nav_libsettings
@@ -97,7 +97,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: 11
       - name: Set up Python for gcovr
         uses: actions/setup-python@v2

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -23,12 +23,10 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - uses: actions/setup-python@v3
-        with:
-          python-version: ">=3 <3.12"
       - uses: docker/setup-qemu-action@v2
         if: ${{ matrix.os.needs_qemu }}
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.13.0 cython
+        run: python -m pip install setuptools cibuildwheel==2.13.0 cython
       - name: Build wheels
         run: |
           cythonize python/libsettings.pyx
@@ -49,10 +47,8 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - uses: actions/setup-python@v3
-        with:
-          python-version: ">=3 <3.12"
       - name: Install build
-        run: python -m pip install build cython
+        run: python -m pip install setuptools build cython
       - name: Build wheels
         run: |
           cythonize python/libsettings.pyx

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -1,12 +1,12 @@
 name: Wheels
-'on':
+"on":
   pull_request: ~
   push:
     branches:
-      - 'master'
+      - "master"
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+*'
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      - "[0-9]+.[0-9]+.[0-9]+*"
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os.name }}
@@ -14,15 +14,17 @@ jobs:
     strategy:
       matrix:
         os:
-          - {name: "ubuntu-20.04", needs_qemu: true}
-          - {name: "windows-2019", needs_qemu: false}
-          - {name: "macOS-11", needs_qemu: false}
+          - { name: "ubuntu-20.04", needs_qemu: true }
+          - { name: "windows-2019", needs_qemu: false }
+          - { name: "macOS-11", needs_qemu: false }
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive
       - uses: actions/setup-python@v3
+        with:
+          python-version: ">=3 <3.12"
       - uses: docker/setup-qemu-action@v2
         if: ${{ matrix.os.needs_qemu }}
       - name: Install cibuildwheel

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -49,6 +49,8 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - uses: actions/setup-python@v3
+        with:
+          python-version: ">=3 <3.12"
       - name: Install build
         run: python -m pip install build cython
       - name: Build wheels


### PR DESCRIPTION
## Rationale

Sonarcloud emits the following warning:

<img width="1687" alt="image" src="https://github.com/swift-nav/libsettings/assets/12671231/34a72119-1508-4337-a040-ca298a00bf5d">


Issue has already been fixed on orion/orion-engine/skylark-fault-injector by updating sonar-scanner's version to `5.0.1.3006`

Note: 

## Testing

Warning does not appear anymore for this PR's analysis:
TODO